### PR TITLE
[CLI Serve] MVP serve functionality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -86,3 +86,6 @@ typings/
 
 # DynamoDB Local files
 .dynamodb/
+
+# VS Code
+.vscode/

--- a/dist/serve.js
+++ b/dist/serve.js
@@ -1,1 +1,25 @@
 "use strict";
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+const express_1 = __importDefault(require("express"));
+const serveController_1 = __importDefault(require("./serveController"));
+const path_1 = __importDefault(require("path"));
+const querystring_1 = __importDefault(require("querystring"));
+const body_parser_1 = __importDefault(require("body-parser"));
+const createHandler = serveController_1.default(path_1.default, querystring_1.default);
+const app = express_1.default();
+app.use(body_parser_1.default.json());
+app.use(body_parser_1.default.urlencoded({ extended: true }));
+const DEFAULT_DIR = 'functions';
+const PORT = 9000;
+app.get('/favicon.ico', function (req, res) {
+    return res.status(204).end();
+});
+app.all('*', createHandler(DEFAULT_DIR, false, 10), (req, res) => {
+    return res.end();
+});
+app.listen(PORT, () => {
+    console.log(`Example app listening on port ${PORT}!`);
+});

--- a/dist/serveController.js
+++ b/dist/serveController.js
@@ -1,0 +1,52 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+// TODO: Proper TypeScript types for modules
+exports.default = (path, queryString) => (dir, useStatic, timeout) => {
+    return function (req, res, next) {
+        const fn = req.path.split('/').filter(name => name)[0];
+        const joinModPath = path.join(process.cwd(), dir, fn);
+        const handler = require(joinModPath);
+        const lambdaReq = {
+            path: req.path,
+            httpMethod: req.method,
+            queryStringParameters: queryString.parse(req.url.split(/\?(.+)/)[1]),
+            headers: req.headers,
+            body: req.body,
+        };
+        const callback = createCallback(res);
+        const promise = handler.handler(lambdaReq, null, callback);
+        Promise.all([promisifyHandler(promise, callback)]) // TODO: Implement promise with timeout
+            .then(() => {
+            return next();
+        })
+            .catch(err => {
+            throw err;
+        });
+    };
+};
+function createCallback(res) {
+    return function callback(err, lambdaRes) {
+        if (err)
+            return err; // TODO: Proper error handling
+        res.statusCode = lambdaRes.statusCode;
+        for (let key in lambdaRes.headers) {
+            res.setHeader(key, lambdaRes.headers[key]);
+        }
+        if (lambdaRes.body) {
+            res.write(lambdaRes.body);
+        }
+    };
+}
+function promisifyHandler(promise, callback) {
+    if (!promise ||
+        typeof promise.then !== 'function' ||
+        typeof callback !== 'function')
+        return;
+    return promise
+        .then((data) => {
+        callback(null, data);
+    })
+        .catch((err) => {
+        callback(err, null);
+    });
+}

--- a/dist/serveController.test.js
+++ b/dist/serveController.test.js
@@ -1,0 +1,131 @@
+"use strict";
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : new P(function (resolve) { resolve(result.value); }).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+const { createHandler, createCallback, promiseHandler, } = require('./serveController')();
+/* Sets up test mocks for Express request and response objects */
+function setup() {
+    const req = {
+        body: {},
+        path: '',
+        url: '',
+    };
+    const res = {
+        locals: {
+            error: {},
+            lambdaResponse: {},
+        },
+        statusCode: null,
+        body: '',
+        headers: {},
+    };
+    const next = jest.fn();
+    Object.assign(res, {
+        status: jest.fn(function status() {
+            return this;
+        }.bind(res)),
+        json: jest.fn(function json() {
+            return this;
+        }.bind(res)),
+        send: jest.fn(function send() {
+            return this;
+        }.bind(res)),
+    });
+    return { req, res, next };
+}
+describe('createHandler', () => {
+    test('Should have proper error object in res.locals if requiring function module fails', () => __awaiter(this, void 0, void 0, function* () {
+        const { req, res, next } = setup();
+        req.path = '/helloasync';
+        const dir = '/functions';
+        const useStatic = false;
+        const timeout = 5;
+        const errorObj = {
+            code: 500,
+            type: 'Server',
+            message: 'Loading function failed',
+        };
+        yield createHandler(dir, useStatic, timeout)(req, res, () => {
+            expect(res.locals.error).toEqual(errorObj);
+        });
+    }));
+    test('Should have a proper error object in res.locals if lambda is not invoked before timeout', () => __awaiter(this, void 0, void 0, function* () {
+        const { req, res, next } = setup();
+        req.path = '/helloasync';
+        const dir = '/functions';
+        const useStatic = false;
+        const timeout = 5;
+        const errorObj = {
+            code: 400,
+            type: 'Client',
+            message: 'Failed to invoke function before timeout',
+        };
+        yield createHandler(dir, useStatic, timeout)(req, res, () => {
+            expect(res.locals.error).not.toEqual(errorObj);
+        });
+    }));
+    test('Should have a proper lambdaResponse object in res.locals', () => __awaiter(this, void 0, void 0, function* () {
+        const { req, res, next } = setup();
+        req.path = '/helloasync';
+        req.url = 'http://localhost:9000/helloasync';
+        const dir = '/functions';
+        const useStatic = false;
+        const timeout = 5;
+        const lambdaResponse = [
+            {
+                statusCode: 200,
+                body: 'Hello, World',
+            },
+        ];
+        yield createHandler(dir, useStatic, timeout)(req, res, () => {
+            expect(res.locals.lambdaResponse).not.toEqual(lambdaResponse);
+        });
+    }));
+});
+describe('createCallback', () => {
+    const res = {
+        headers: {
+            'Access-Control-Allow-Origin': '*',
+            'Access-Control-Allow-Headers': 'Content-Type',
+        },
+        statusCode: 200,
+        body: 'Why should you never trust a pig with a ' +
+            "secret? Because it's bound to squeal.",
+    };
+    test('Should return a function', () => __awaiter(this, void 0, void 0, function* () {
+        const res = {};
+        yield expect(typeof createCallback(res)).toEqual('function');
+    }));
+    test('Returned callback should be able to handle errors', () => __awaiter(this, void 0, void 0, function* () {
+        const res = {
+            headers: {
+                'Access-Control-Allow-Origin': '*',
+                'Access-Control-Allow-Headers': 'Content-Type',
+            },
+            statusCode: 200,
+            body: 'Why should you never trust a pig with a ' +
+                "secret? Because it's bound to squeal.",
+        };
+        const returnFunc = yield createCallback(res);
+        expect(returnFunc(new Error('this is an error'), null)).toBeInstanceOf(Error);
+    }));
+    test('Callback should set proper response object with status code, headers, and body', () => __awaiter(this, void 0, void 0, function* () {
+        const { res } = setup();
+        const lambdaResponse = {
+            statusCode: 200,
+            headers: {
+                header1: 'Facebook',
+                header2: 'Google',
+            },
+            body: 'Hello, World',
+        };
+        yield createCallback(res)(null, lambdaResponse);
+        yield expect(res).toMatchObject(lambdaResponse);
+    }));
+});
+describe('promiseHandler', () => { });

--- a/functions/hello.js
+++ b/functions/hello.js
@@ -1,6 +1,6 @@
-exports.handler = function (event, context, callback) {
+exports.handler = function(event, context, callback) {
   callback(null, {
     statusCode: 200,
-    body: "Hello, World"
+    body: 'Hello, Jun',
   });
 };

--- a/functions/helloAsync.js
+++ b/functions/helloAsync.js
@@ -1,6 +1,6 @@
 exports.handler = async (event, context) => {
   return {
     statusCode: 200,
-    body: "Hello, World"
+    body: 'Hello, Jayvee',
   };
 };

--- a/functions/helloName.js
+++ b/functions/helloName.js
@@ -1,8 +1,8 @@
 exports.handler = async (event, context) => {
-  const name = event.queryStringParameters.name || "World";
+  const name = event.queryStringParameters.name || 'World';
 
   return {
     statusCode: 200,
-    body: `Hello, ${name}`
+    body: `Hello, ${name}`,
   };
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1830,7 +1830,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -1851,12 +1852,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -1871,17 +1874,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -1998,7 +2004,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -2010,6 +2017,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -2024,6 +2032,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -2031,12 +2040,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -2055,6 +2066,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -2135,7 +2147,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -2147,6 +2160,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -2232,7 +2246,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -2268,6 +2283,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -2287,6 +2303,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -2330,12 +2347,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -4,11 +4,13 @@
   "description": "Serve, build, and deploy AWS Lambda functions",
   "main": "index.js",
   "dependencies": {
+    "body-parser": "^1.19.0",
     "express": "^4.17.1",
     "node-fetch": "^2.6.0",
     "querystring": "^0.2.0"
   },
   "devDependencies": {
+    "@types/body-parser": "^1.17.0",
     "@types/express": "^4.17.0",
     "@types/jest": "^24.0.15",
     "@types/node": "^12.0.10",

--- a/src/serve/serve.ts
+++ b/src/serve/serve.ts
@@ -1,0 +1,25 @@
+import express from 'express';
+import serve from './serveController';
+import path from 'path';
+import queryString from 'querystring';
+import bodyParser from 'body-parser';
+const createHandler = serve(path, queryString);
+
+const app: express.Application = express();
+app.use(bodyParser.json());
+app.use(bodyParser.urlencoded({ extended: true }));
+
+const DEFAULT_DIR: string = 'functions';
+const PORT = 9000;
+
+app.get('/favicon.ico', function(req, res) {
+  return res.status(204).end();
+});
+
+app.all('*', createHandler(DEFAULT_DIR, false, 10), (req, res) => {
+  return res.end();
+});
+
+app.listen(PORT, () => {
+  console.log(`Example app listening on port ${PORT}!`);
+});

--- a/src/serve/serveController.js
+++ b/src/serve/serveController.js
@@ -1,2 +1,0 @@
-"use strict";
-//# sourceMappingURL=serveController.js.map

--- a/src/serve/serveController.test.ts
+++ b/src/serve/serveController.test.ts
@@ -1,15 +1,15 @@
 const {
   createHandler,
   createCallback,
-  promiseHandler
-} = require("./serveController")();
+  promiseHandler,
+} = require('./serveController')();
 
 /* Sets up test mocks for Express request and response objects */
 function setup() {
   const req = {
     body: {},
-    path: "",
-    url: ""
+    path: '',
+    url: '',
   };
   const res = {
     locals: {
@@ -18,7 +18,7 @@ function setup() {
     },
     statusCode: null,
     body: '',
-    headers: {}
+    headers: {},
   };
   const next = jest.fn();
   Object.assign(res, {
@@ -36,56 +36,56 @@ function setup() {
       function send(this: object) {
         return this;
       }.bind(res)
-    )
+    ),
   });
   return { req, res, next };
 }
 
-describe("createHandler", () => {
-  test("Should have proper error object in res.locals if requiring function module fails", async () => {
+describe('createHandler', () => {
+  test('Should have proper error object in res.locals if requiring function module fails', async () => {
     const { req, res, next } = setup();
-    req.path = "/helloasync";
-    const dir = "/functions";
+    req.path = '/helloasync';
+    const dir = '/functions';
     const useStatic = false;
     const timeout = 5;
     const errorObj = {
       code: 500,
-      type: "Server",
-      message: "Loading function failed"
+      type: 'Server',
+      message: 'Loading function failed',
     };
     await createHandler(dir, useStatic, timeout)(req, res, () => {
       expect(res.locals.error).toEqual(errorObj);
     });
   });
 
-  test("Should have a proper error object in res.locals if lambda is not invoked before timeout", async () => {
+  test('Should have a proper error object in res.locals if lambda is not invoked before timeout', async () => {
     const { req, res, next } = setup();
-    req.path = "/helloasync";
-    const dir = "/functions";
+    req.path = '/helloasync';
+    const dir = '/functions';
     const useStatic = false;
     const timeout = 5;
     const errorObj = {
       code: 400,
-      type: "Client",
-      message: "Failed to invoke function before timeout"
+      type: 'Client',
+      message: 'Failed to invoke function before timeout',
     };
     await createHandler(dir, useStatic, timeout)(req, res, () => {
       expect(res.locals.error).not.toEqual(errorObj);
     });
   });
 
-  test("Should have a proper lambdaResponse object in res.locals", async () => {
+  test('Should have a proper lambdaResponse object in res.locals', async () => {
     const { req, res, next } = setup();
-    req.path = "/helloasync";
-    req.url = "http://localhost:9000/helloasync";
-    const dir = "/functions";
+    req.path = '/helloasync';
+    req.url = 'http://localhost:9000/helloasync';
+    const dir = '/functions';
     const useStatic = false;
     const timeout = 5;
     const lambdaResponse = [
       {
         statusCode: 200,
-        body: "Hello, World"
-      }
+        body: 'Hello, World',
+      },
     ];
     await createHandler(dir, useStatic, timeout)(req, res, () => {
       expect(res.locals.lambdaResponse).not.toEqual(lambdaResponse);
@@ -107,7 +107,7 @@ describe('createCallback', () => {
 
   test('Should return a function', async () => {
     const res = {};
-    await expect(typeof createCallback(res)).toEqual('function')
+    await expect(typeof createCallback(res)).toEqual('function');
   });
 
   test('Returned callback should be able to handle errors', async () => {
@@ -121,9 +121,11 @@ describe('createCallback', () => {
         'Why should you never trust a pig with a ' +
         "secret? Because it's bound to squeal.",
     };
-    const returnFunc = await createCallback(res)
-    expect(returnFunc(new Error('this is an error'), null)).toBeInstanceOf(Error)
-  })
+    const returnFunc = await createCallback(res);
+    expect(returnFunc(new Error('this is an error'), null)).toBeInstanceOf(
+      Error
+    );
+  });
 
   test('Callback should set proper response object with status code, headers, and body', async () => {
     const { res } = setup();
@@ -131,13 +133,12 @@ describe('createCallback', () => {
       statusCode: 200,
       headers: {
         header1: 'Facebook',
-        header2: 'Google'
+        header2: 'Google',
       },
       body: 'Hello, World',
     };
     await createCallback(res)(null, lambdaResponse);
     await expect(res).toMatchObject(lambdaResponse);
-  })
-
+  });
 });
-describe('promiseHandler', () => { });
+describe('promiseHandler', () => {});

--- a/src/serve/serveController.ts
+++ b/src/serve/serveController.ts
@@ -1,47 +1,60 @@
-import express from "express";
-import path from "path";
-import queryString from "querystring";
+import { Request, Response } from 'express';
 
-const app: Express.Application = express();
-module.exports = () => ({
-  createHandler: (dir: string, useStatic: boolean, timeout: number) => {
-    return function (
-      req: Express.Request,
-      res: Express.Response,
-      next: Function
-    ) {
-      const fn: string = req.path.split("/").filter(name => name)[0];
-      const joinModPath = path.join(process.cwd(), dir, fn);
-      const handler = require(joinModPath);
-      const lambdaReq = {
-        path: req.path,
-        httpMethod: req.method,
-        queryStringParameters: queryString.parse(req.url.split(/\?(.+)/)[1]),
-        headers: req.headers,
-        body: req.body
-      };
-
-      const promise = handler.handler(lambdaReq, null, null);
-      Promise.all([promise]).then(result => res.send(result));
-      return;
+// TODO: Proper TypeScript types for modules
+export default (path: { join: Function }, queryString: { parse: Function }) => (
+  dir: string,
+  useStatic: boolean,
+  timeout: number
+) => {
+  return function(req: Request, res: Response, next: Function) {
+    const fn: string = req.path.split('/').filter(name => name)[0];
+    const joinModPath = path.join(process.cwd(), dir, fn);
+    const handler = require(joinModPath);
+    const lambdaReq = {
+      path: req.path,
+      httpMethod: req.method,
+      queryStringParameters: queryString.parse(req.url.split(/\?(.+)/)[1]),
+      headers: req.headers,
+      body: req.body,
     };
-  },
-  //headers are for now any.. will find bette way later
-  createCallback: (res: { body: string; statusCode: number; headers: any }) => {
-    // res.body = 'sadf';
-    return function callback(err: Error, lambdaResponse: any) {
-      // res.body = 'sadf';
-      // console.log(lambdaResponse);
-      if (err) return err
-      res.statusCode = lambdaResponse.statusCode;
-      for (let key in lambdaResponse.headers) {
-        res.headers[key] = lambdaResponse.headers[key];
-      }
+    const callback = createCallback(res);
+    const promise = handler.handler(lambdaReq, null, callback);
+    Promise.all([promisifyHandler(promise, callback)]) // TODO: Implement promise with timeout
+      .then(() => {
+        return next();
+      })
+      .catch(err => {
+        throw err;
+      });
+  };
+};
 
-      if (lambdaResponse.body) {
-        res.body = lambdaResponse.body;
-      }
+function createCallback(res: Response) {
+  return function callback(err: Error | null, lambdaRes: any) {
+    if (err) return err; // TODO: Proper error handling
+    res.statusCode = lambdaRes.statusCode;
+    for (let key in lambdaRes.headers) {
+      res.setHeader(key, lambdaRes.headers[key]);
     }
-  },
-  promiseHandler: (promise: Function, cb: Function) => { },
-});
+    if (lambdaRes.body) {
+      res.write(lambdaRes.body);
+    }
+  };
+}
+
+function promisifyHandler(promise: { then: Function }, callback: Function) {
+  if (
+    !promise ||
+    typeof promise.then !== 'function' ||
+    typeof callback !== 'function'
+  )
+    return;
+
+  return promise
+    .then((data: object) => {
+      callback(null, data);
+    })
+    .catch((err: Error | null) => {
+      callback(err, null);
+    });
+}


### PR DESCRIPTION
CLI needs to serve functions locally for lambda testing. This PR accomplishes the MVP functionality of the CLI's Serve function. Merged changes from @jushuworld  , @esthleej , and @javs-24 and added the following:

- `serve.ts` serves local Express app that receives incoming requests to `http://localhost:9000` and parses out function name from request path

- `createHandler` middleware in `serveController.ts` parses out handlers from user's functions directory and simulates Lambdas with helper functions `createCallback` and `promisifyHandler`.